### PR TITLE
Remove trailing newline from logs

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -215,7 +215,7 @@ int vpn_ws_connect(vpn_ws_peer *peer, char *name) {
 	int ssl = 0;
 	uint16_t port = 80;
 	if (strlen(cpy) < 6) {
-		vpn_ws_log("invalid websocket url: %s\n", cpy);
+		vpn_ws_log("invalid websocket url: %s", cpy);
 		return -1;
 	}
 
@@ -228,7 +228,7 @@ int vpn_ws_connect(vpn_ws_peer *peer, char *name) {
 		port = 80;
 	}
 	else {
-		vpn_ws_log("invalid websocket url: %s (requires ws:// or wss://)\n", cpy);
+		vpn_ws_log("invalid websocket url: %s (requires ws:// or wss://)", cpy);
 		return -1;
 	}
 
@@ -260,12 +260,12 @@ int vpn_ws_connect(vpn_ws_peer *peer, char *name) {
 		port = atoi(port_str+1);
 	}
 
-	vpn_ws_log("connecting to %s port %u (transport: %s)\n", domain, port, ssl ? "wss": "ws");
+	vpn_ws_log("connecting to %s port %u (transport: %s)", domain, port, ssl ? "wss": "ws");
 
 	// resolve the domain
 	struct hostent *he = gethostbyname(domain);
 	if (!he) {
-		vpn_ws_log("vpn_ws_connect()/gethostbyname(): unable to resolve name\n");
+		vpn_ws_log("vpn_ws_connect()/gethostbyname(): unable to resolve name");
 		return -1;
 	}
 
@@ -356,11 +356,11 @@ int vpn_ws_connect(vpn_ws_peer *peer, char *name) {
 
 	int http_code = vpn_ws_wait_101(peer->fd, vpn_ws_conf.ssl_ctx);
 	if (http_code != 101) {
-		vpn_ws_log("error, websocket handshake returned code: %d\n", http_code);
+		vpn_ws_log("error, websocket handshake returned code: %d", http_code);
 		return -1;
 	}
 
-	vpn_ws_log("connected to %s port %u (transport: %s)\n", domain, port, ssl ? "wss": "ws");
+	vpn_ws_log("connected to %s port %u (transport: %s)", domain, port, ssl ? "wss": "ws");
 	return 0;
 }
 
@@ -396,13 +396,13 @@ int main(int argc, char *argv[]) {
                         case '?':
                                 break;
                         default:
-                                vpn_ws_log("error parsing arguments\n");
+                                vpn_ws_log("error parsing arguments");
                                 vpn_ws_exit(1);
                 }
         }
 
 	if (optind + 1 >= argc) {
-		vpn_ws_log("syntax: %s <tap> <ws>\n", argv[0]);
+		vpn_ws_log("syntax: %s <tap> <ws>", argv[0]);
 		vpn_ws_exit(1);
 	}
 
@@ -438,7 +438,7 @@ int main(int argc, char *argv[]) {
 	// back here whenever the server disconnect
 reconnect:
 	if (throttle > -1) {
-		vpn_ws_log("disconnected\n");
+		vpn_ws_log("disconnected");
 	}
 	if (throttle >= 30) throttle = 0;
 	throttle++;

--- a/src/error.c
+++ b/src/error.c
@@ -1,7 +1,7 @@
 #include "vpn-ws.h"
 
 void vpn_ws_error(char *msg) {
-	vpn_ws_log("%s: %s\n", msg, strerror(errno));
+	vpn_ws_log("%s: %s", msg, strerror(errno));
 }
 
 void vpn_ws_exit(int code) {
@@ -15,4 +15,5 @@ void vpn_ws_log(char *fmt, ...) {
 	va_start(args, fmt);
 	vfprintf(stdout, fmt, args);
 	va_end(args);
+	fputc('\n', stdout);
 }

--- a/src/exec.c
+++ b/src/exec.c
@@ -20,7 +20,7 @@ int vpn_ws_exec(char *cmd) {
 		if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
 			return 0;
 		}
-		vpn_ws_log("vpn_ws_exec() returned non-zero code: %d\n", WEXITSTATUS(status));
+		vpn_ws_log("vpn_ws_exec() returned non-zero code: %d", WEXITSTATUS(status));
 		return -1;
 	}
 
@@ -62,7 +62,7 @@ end:
 	CloseHandle(pinfo.hProcess);	
 	CloseHandle(pinfo.hThread);	
 	if (code == 0) return 0;
-	vpn_ws_log("vpn_ws_exec() returned non-zero code: %d\n", code);
+	vpn_ws_log("vpn_ws_exec() returned non-zero code: %d", code);
 	return -1;
 }
 

--- a/src/io.c
+++ b/src/io.c
@@ -125,14 +125,14 @@ int vpn_ws_manage_fd(int queue, vpn_ws_fd fd) {
 	vpn_ws_peer *peer = NULL;
 #endif
 	if (!peer) {
-		vpn_ws_log("[BUG] fd %d not found\n", fd);
+		vpn_ws_log("[BUG] fd %d not found", fd);
 		close(fd);
 		return -1;
 	}
 
 	// is it valid ?
 	if (peer->fd != fd) {
-		vpn_ws_log("[BUG] found invalid peer %d != %d \n", peer->fd, fd);
+		vpn_ws_log("[BUG] found invalid peer %d != %d", peer->fd, fd);
 		vpn_ws_peer_destroy(peer);
 		close(fd);
 		return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
 				fprintf(stdout, "\t--help\t\t\tthis help\n");
 				exit(0);
 			default:
-				vpn_ws_log("error parsing arguments\n");
+				vpn_ws_log("error parsing arguments");
 				vpn_ws_exit(1);
 		}
 	}
@@ -70,8 +70,8 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (!vpn_ws_conf.server_addr) {
-		vpn_ws_log("you need to specify a socket address\n");
-                vpn_ws_exit(1);
+		vpn_ws_log("you need to specify a socket address");
+    vpn_ws_exit(1);
 	}
 
 	server_fd = vpn_ws_bind(vpn_ws_conf.server_addr);
@@ -122,7 +122,7 @@ int main(int argc, char *argv[]) {
 				gid = atoi(vpn_ws_conf.gid);
 			}
 			else {
-				vpn_ws_log("unable to find group %s\n", vpn_ws_conf.gid);
+				vpn_ws_log("unable to find group %s", vpn_ws_conf.gid);
 				vpn_ws_exit(1);
 			}
 		}
@@ -130,7 +130,7 @@ int main(int argc, char *argv[]) {
 			gid = g->gr_gid;
 		}
 		if (!gid) {
-			vpn_ws_log("unable to drop to gid\n");
+			vpn_ws_log("unable to drop to gid");
 			vpn_ws_exit(1);
 		}
 		if (setgid(gid)) {
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
                                 uid = atoi(vpn_ws_conf.uid);
                         }
                         else {
-                                vpn_ws_log("unable to find user %s\n", vpn_ws_conf.uid);
+                                vpn_ws_log("unable to find user %s", vpn_ws_conf.uid);
                                 vpn_ws_exit(1);
                         }
                 }
@@ -155,7 +155,7 @@ int main(int argc, char *argv[]) {
                         uid = p->pw_uid;
                 }
                 if (!uid) {
-                        vpn_ws_log("unable to drop to uid\n");
+                        vpn_ws_log("unable to drop to uid");
                         vpn_ws_exit(1);
                 }
                 if (setuid(uid)) {

--- a/src/socket.c
+++ b/src/socket.c
@@ -109,7 +109,7 @@ vpn_ws_fd vpn_ws_bind_ipv4(char *name) {
 vpn_ws_fd vpn_ws_bind_unix(char *name) {
 
 #ifdef __WIN32__
-	vpn_ws_log("UNIX domain sockets not supported on windows\n");
+	vpn_ws_log("UNIX domain sockets not supported on windows");
 	return NULL;
 #else
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -98,7 +98,7 @@ void *vpn_ws_ssl_handshake(vpn_ws_peer *peer, char *sni, char *key, char *crt) {
 
 	err = SSLSetConnection(ctx, peer);
 	if (err != noErr) {
-		vpn_ws_log("vpn_ws_ssl_handshake()/SSLSetConnection(): %d\n", err);
+		vpn_ws_log("vpn_ws_ssl_handshake()/SSLSetConnection(): %d", err);
 		goto error;
 	}
 
@@ -106,7 +106,7 @@ void *vpn_ws_ssl_handshake(vpn_ws_peer *peer, char *sni, char *key, char *crt) {
 	if (vpn_ws_conf.ssl_no_verify) {
 		err = SSLSetSessionOption(ctx, kSSLSessionOptionBreakOnServerAuth, true);
 		if (err != noErr) {
-			vpn_ws_log("vpn_ws_ssl_handshake()/SSLSetSessionOption(): %d\n", err);
+			vpn_ws_log("vpn_ws_ssl_handshake()/SSLSetSessionOption(): %d", err);
 			goto error;
 		}
 	}
@@ -133,22 +133,22 @@ void *vpn_ws_ssl_handshake(vpn_ws_peer *peer, char *sni, char *key, char *crt) {
 		err = SecItemCopyMatching(dict, (CFTypeRef *)&sec[0]);
 		CFRelease(dict);
 		if (err != noErr) {
-                        vpn_ws_log("vpn_ws_ssl_handshake()/SecItemCopyMatching(): %d\n", err);
-                        goto error;
-                }
+			vpn_ws_log("vpn_ws_ssl_handshake()/SecItemCopyMatching(): %d", err);
+			goto error;
+		}
 		CFArrayRef certs = CFArrayCreate(NULL, (const void **)sec, 1, &kCFTypeArrayCallBacks);	
 		err = SSLSetCertificate(ctx, certs);
 		if(certs) CFRelease(certs);
 		CFRelease(sec[0]);
 		if (err != noErr) {
-			vpn_ws_log("vpn_ws_ssl_handshake()/SSLSetCertificate(): %d\n", err);
-                        goto error;
+			vpn_ws_log("vpn_ws_ssl_handshake()/SSLSetCertificate(): %d", err);
+			goto error;
 		}
 	}
 
 	err = SSLSetPeerDomainName(ctx, sni, strlen(sni));
 	if (err != noErr) {
-		vpn_ws_log("vpn_ws_ssl_handshake()/SSLSetPeerDomainName(): %d\n", err);
+		vpn_ws_log("vpn_ws_ssl_handshake()/SSLSetPeerDomainName(): %d", err);
 		goto error;
 	}
 
@@ -156,8 +156,8 @@ void *vpn_ws_ssl_handshake(vpn_ws_peer *peer, char *sni, char *key, char *crt) {
 		err = SSLHandshake(ctx);
 		if (err != noErr) {
 			if (err == errSSLServerAuthCompleted) continue;
-			vpn_ws_log("vpn_ws_ssl_handshake()/SSLHandshake(): %d\n", err);
-                	goto error;
+			vpn_ws_log("vpn_ws_ssl_handshake()/SSLHandshake(): %d", err);
+			goto error;
 		}
 		break;
 	}
@@ -195,7 +195,7 @@ void vpn_ws_ssl_close(void *ctx) {
 #include <sspi.h>
 void *vpn_ws_ssl_handshake(vpn_ws_peer *peer, char *sni, char *key, char *crt) {
 	PSecurityFunctionTable sec = InitSecurityInterfaceA();
-	vpn_ws_log("%p\n", sec);
+	vpn_ws_log("%p", sec);
 	return sec;
 }
 
@@ -239,7 +239,7 @@ void *vpn_ws_ssl_handshake(vpn_ws_peer *peer, char *sni, char *key, char *crt) {
 	if (!ssl_ctx) {
 		ssl_ctx = SSL_CTX_new(SSLv23_client_method());
 		if (!ssl_ctx) {
-			vpn_ws_log("vpn_ws_ssl_handshake(): unable to initialize context\n");
+			vpn_ws_log("vpn_ws_ssl_handshake(): unable to initialize context");
 			return NULL;
 		}
 		long ssloptions = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_ALL | SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
@@ -261,7 +261,7 @@ void *vpn_ws_ssl_handshake(vpn_ws_peer *peer, char *sni, char *key, char *crt) {
 
 		if (key) {
 			if (SSL_CTX_use_PrivateKey_file(ssl_ctx, key, SSL_FILETYPE_PEM) <= 0) {
-				vpn_ws_log("vpn_ws_ssl_handshake(): unable to load key %s\n", key);
+				vpn_ws_log("vpn_ws_ssl_handshake(): unable to load key %s", key);
 				SSL_CTX_free(ssl_ctx);
 				ssl_ctx = NULL;	
 				return NULL;
@@ -270,7 +270,7 @@ void *vpn_ws_ssl_handshake(vpn_ws_peer *peer, char *sni, char *key, char *crt) {
 
 		if (crt) {
 			if (SSL_CTX_use_certificate_chain_file(ssl_ctx, crt) <= 0) {
-				vpn_ws_log("vpn_ws_ssl_handshake(): unable to load certificate %s\n", crt);
+				vpn_ws_log("vpn_ws_ssl_handshake(): unable to load certificate %s", crt);
 				SSL_CTX_free(ssl_ctx);
 				ssl_ctx = NULL;	
 				return NULL;
@@ -281,7 +281,7 @@ void *vpn_ws_ssl_handshake(vpn_ws_peer *peer, char *sni, char *key, char *crt) {
 
 	SSL *ssl = SSL_new(ssl_ctx);
 	if (!ssl) {
-		vpn_ws_log("vpn_ws_ssl_handshake(): unable to initialize session\n");
+		vpn_ws_log("vpn_ws_ssl_handshake(): unable to initialize session");
 		return NULL;
 	}
 	SSL_set_fd(ssl, peer->fd);
@@ -312,7 +312,7 @@ void *vpn_ws_ssl_handshake(vpn_ws_peer *peer, char *sni, char *key, char *crt) {
 
 error:
 	err = ERR_get_error_line_data(NULL, NULL, NULL, NULL);
-	vpn_ws_log("vpn_ws_ssl_handshake(): %s\n", ERR_error_string(err, NULL));
+	vpn_ws_log("vpn_ws_ssl_handshake(): %s", ERR_error_string(err, NULL));
 	ERR_clear_error();
 	SSL_free(ssl);
 	return NULL;

--- a/src/utils.c
+++ b/src/utils.c
@@ -20,9 +20,9 @@ void vpn_ws_announce_peer(vpn_ws_peer *peer, char *msg) {
 	if (peer->raw) return;
 	if (!peer->mac_collected) return;
 #ifndef __WIN32__
-	vpn_ws_log("%s peer %d MAC=%02X:%02X:%02X:%02X:%02X:%02X REMOTE_ADDR=%s REMOTE_USER=%s DN=%s\n"
+	vpn_ws_log("%s peer %d MAC=%02X:%02X:%02X:%02X:%02X:%02X REMOTE_ADDR=%s REMOTE_USER=%s DN=%s"
 #else
-	vpn_ws_log("%s peer %p MAC=%02X:%02X:%02X:%02X:%02X:%02X REMOTE_ADDR=%s REMOTE_USER=%s DN=%s\n"
+	vpn_ws_log("%s peer %p MAC=%02X:%02X:%02X:%02X:%02X:%02X REMOTE_ADDR=%s REMOTE_USER=%s DN=%s"
 #endif
 			,msg,
 			peer->fd,


### PR DESCRIPTION
If logs were implemented not to write directly to the console,
this would add noise.